### PR TITLE
Fix hls management

### DIFF
--- a/classes/output/view.php
+++ b/classes/output/view.php
@@ -186,6 +186,7 @@ class view {
                         (int)$this->supervideoview->id,
                         $this->supervideoview->currenttime,
                         $elementid,
+                        $mustachedata["hls"],
                     ]
                 );
                 $this->create_errosmessages();


### PR DESCRIPTION
Add missing parameters when calling player create javascript

Ajout du paramètre manquant pour spécifier au builder qu'il s'agit d'un lien hls